### PR TITLE
feat(#21): add `terrain_prompt` function in zsh for prompt output

### DIFF
--- a/schema/terrain-schema.json
+++ b/schema/terrain-schema.json
@@ -5,11 +5,15 @@
   "required": [
     "auto_apply",
     "biomes",
+    "name",
     "terrain"
   ],
   "properties": {
     "schema": {
       "default": "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json",
+      "type": "string"
+    },
+    "name": {
       "type": "string"
     },
     "auto_apply": {

--- a/scripts/terrainium_init
+++ b/scripts/terrainium_init
@@ -4,22 +4,22 @@ if [ -z "$TERRAINIUM_EXECUTABLE" ]; then
     TERRAINIUM_EXECUTABLE=terrainium
 fi
 
-if [ "$TERRAIN_ENABLED" = "true" ];then
-    # clear
+if [ "$TERRAIN_ENABLED" = "true" ]; then
     autoload -Uzw "${TERRAIN_INIT_SCRIPT}"
     "${terrain_init}"
-    # builtin unfunction -- "${terrainium_init}"
+    builtin unfunction -- "${terrain_init}"
     terrainium_enter
-    echo init....
 fi
 
 function terrainium_chpwd_functions() {
     if [ "$TERRAIN_ENABLED" != "true" ]; then
         auto_apply="$($TERRAINIUM_EXECUTABLE get --auto-apply 2> /dev/null)"
-        if [ $? != 0 ];then auto_apply="off";fi
+        if [ $? != 0 ]; then
+            auto_apply="off"
+        fi
         if [ "$auto_apply" = "enabled" ] || [ "$auto_apply" = "background" ]; then
             "$TERRAINIUM_EXECUTABLE" enter --auto-apply
-        elif [ "$auto_apply" = "replaced" ]; then
+        elif [ "$auto_apply" = "replaced" ] || [ "$auto_apply" = "all" ]; then
             exec "$TERRAINIUM_EXECUTABLE" enter --auto-apply
         fi
     fi

--- a/src/client/types/environment.rs
+++ b/src/client/types/environment.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize, Debug, PartialEq)]
 pub struct Environment {
+    name: String,
     default_biome: Option<String>,
     selected_biome: String,
     auto_apply: AutoApply,
@@ -26,6 +27,7 @@ impl Environment {
         });
 
         Ok(Environment {
+            name: terrain.name().clone(),
             default_biome: terrain.default_biome().clone(),
             selected_biome: selected,
             auto_apply: terrain.auto_apply().clone(),
@@ -56,6 +58,7 @@ impl Environment {
     #[cfg(test)]
     pub fn build(default_biome: Option<String>, selected_biome: String, merged: &Biome) -> Self {
         Environment {
+            name: "terrainium".to_string(),
             default_biome,
             selected_biome,
             auto_apply: AutoApply::default(),

--- a/src/client/types/terrain.rs
+++ b/src/client/types/terrain.rs
@@ -14,6 +14,7 @@ pub struct Terrain {
     #[serde(default = "schema_url", rename(serialize = "$schema"))]
     schema: String,
 
+    name: String,
     auto_apply: AutoApply,
     terrain: Biome,
     biomes: BTreeMap<String, Biome>,
@@ -107,7 +108,16 @@ impl Terrain {
         default_biome: Option<String>,
         auto_apply: AutoApply,
     ) -> Self {
+        let name = std::env::current_dir()
+            .expect("failed to get current directory")
+            .file_name()
+            .expect("failed to get current directory name")
+            .to_str()
+            .expect("failed to convert directory name to string")
+            .to_string();
+
         Terrain {
+            name,
             schema: schema_url(),
             auto_apply,
             terrain,
@@ -118,6 +128,10 @@ impl Terrain {
 
     pub fn default_biome(&self) -> &Option<String> {
         &self.default_biome
+    }
+
+    pub fn name(&self) -> &String {
+        &self.name
     }
 
     pub fn terrain(&self) -> &Biome {

--- a/templates/zsh_final_script.hbs
+++ b/templates/zsh_final_script.hbs
@@ -30,6 +30,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "{{ this.name }}({{ this.selected_biome }})"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/terrain.toml
+++ b/terrain.toml
@@ -1,10 +1,11 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "test"
 
 [auto_apply]
 enabled = true
 background = false
-replace = false
+replace = true
 
 [terrain.envs]
 TERRAINIUM_DEV = "false"

--- a/tests/data/terrain-example_biome.example.example_biome.updated.zsh
+++ b/tests/data/terrain-example_biome.example.example_biome.updated.zsh
@@ -35,6 +35,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(example_biome)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain-example_biome.example.none.updated.zsh
+++ b/tests/data/terrain-example_biome.example.none.updated.zsh
@@ -35,6 +35,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(example_biome)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain-example_biome.example.zsh
+++ b/tests/data/terrain-example_biome.example.zsh
@@ -34,6 +34,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(example_biome)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain-example_biome2.example.zsh
+++ b/tests/data/terrain-example_biome2.example.zsh
@@ -34,6 +34,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(example_biome2)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain-none.empty.zsh
+++ b/tests/data/terrain-none.empty.zsh
@@ -26,6 +26,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(none)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain-none.example.none.updated.zsh
+++ b/tests/data/terrain-none.example.none.updated.zsh
@@ -33,6 +33,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(none)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain-none.example.zsh
+++ b/tests/data/terrain-none.example.zsh
@@ -32,6 +32,12 @@ function terrainium_enter() {
     terrainium_shell_constructor
 }
 
+function terrain_prompt() {
+    if [ "$TERRAIN_ENABLED" = "true" ]; then
+        echo "terrainium(none)"
+    fi
+}
+
 function terrainium_exit() {
     if [ "$TERRAIN_ENABLED" = "true" ]; then
         builtin exit

--- a/tests/data/terrain.empty.auto_apply.all.toml
+++ b/tests/data/terrain.empty.auto_apply.all.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 
 [auto_apply]
 enabled = true

--- a/tests/data/terrain.empty.toml
+++ b/tests/data/terrain.empty.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 
 [auto_apply]
 enabled = false

--- a/tests/data/terrain.example.auto_apply.all.toml
+++ b/tests/data/terrain.example.auto_apply.all.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.auto_apply.background.toml
+++ b/tests/data/terrain.example.auto_apply.background.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.auto_apply.enabled.toml
+++ b/tests/data/terrain.example.auto_apply.enabled.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.auto_apply.replace.toml
+++ b/tests/data/terrain.example.auto_apply.replace.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.example_biome.updated.toml
+++ b/tests/data/terrain.example.example_biome.updated.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.new.example_biome2.toml
+++ b/tests/data/terrain.example.new.example_biome2.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.none.updated.toml
+++ b/tests/data/terrain.example.none.updated.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.toml
+++ b/tests/data/terrain.example.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.without.background.auto_apply.background.toml
+++ b/tests/data/terrain.example.without.background.auto_apply.background.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 default_biome = "example_biome"
 
 [auto_apply]

--- a/tests/data/terrain.example.without.default.toml
+++ b/tests/data/terrain.example.without.default.toml
@@ -1,4 +1,5 @@
 "$schema" = "https://raw.githubusercontent.com/csd1100/terrainium/main/schema/terrain-schema.json"
+name = "terrainium"
 
 [auto_apply]
 enabled = false


### PR DESCRIPTION
- Add name field to terrain which on init will be current directory name
- Will print prompt value of <terrain_name>(selected_biome)
- Fixed auto_apply not working when "all"